### PR TITLE
Fix/prevent human label loss 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,18 @@ inputs:
   pr-number:
     description: 'The pull request number(s)'
     required: false
+  debug-delay-before-fetch-ms:
+    description: 'Debug delay in ms before fetching PR labels'
+    required: false
+    default: '0'
+  debug-delay-before-set-ms:
+    description: 'Debug delay in ms before calling setLabels'
+    required: false
+    default: '0'
+  debug-delay-after-set-ms:
+    description: 'Debug delay in ms after calling setLabels'
+    required: false
+    default: '0'
 
 outputs:
   new-labels:

--- a/dist/index.js
+++ b/dist/index.js
@@ -1096,6 +1096,8 @@ function labeler() {
                 }
                 try {
                     if (!(0, lodash_isequal_1.default)(labelsToAdd, preexistingLabels)) {
+                        core.info(`[debug] Snapshot preexistingLabels: ${JSON.stringify(preexistingLabels)}`);
+                        core.info(`[debug] About to set labels: ${JSON.stringify(labelsToAdd)}`);
                         yield api.setLabels(client, pullRequest.number, labelsToAdd);
                         newLabels = labelsToAdd.filter(label => !preexistingLabels.includes(label));
                     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -1126,13 +1126,14 @@ function labeler() {
                         ])).slice(0, GITHUB_MAX_LABELS);
                         yield api.setLabels(client, pullRequest.number, finalLabels);
                         // Ensure outputs are scoped to the current PR
-                        newLabels = labelsToAdd.filter(label => !preexistingLabels.includes(label));
+                        newLabels = finalLabels.filter(label => !preexistingLabels.includes(label));
                         core.debug(`Processing PR #${pullRequest.number}`);
                         core.debug(`Latest labels: ${JSON.stringify(latestLabels)}`);
                         core.debug(`Labels to add: ${JSON.stringify(labelsToAdd)}`);
                         core.debug(`Final labels: ${JSON.stringify(finalLabels)}`);
                         core.setOutput('new-labels', newLabels.join(','));
-                        core.setOutput('all-labels', [...allLabels].join(','));
+                        // core.setOutput('all-labels', [...allLabels].join(','));
+                        core.setOutput('all-labels', finalLabels.join(','));
                     }
                 }
                 catch (error) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1102,7 +1102,9 @@ function labeler() {
                         const latestLabels = [];
                         if (process.env.NODE_ENV !== 'test') {
                             try {
-                                for (var _h = true, _j = (e_2 = void 0, __asyncValues(api.getPullRequests(client, [pullRequest.number]))), _k; _k = yield _j.next(), _d = _k.done, !_d; _h = true) {
+                                for (var _h = true, _j = (e_2 = void 0, __asyncValues(api.getPullRequests(client, [
+                                    pullRequest.number
+                                ]))), _k; _k = yield _j.next(), _d = _k.done, !_d; _h = true) {
                                     _f = _k.value;
                                     _h = false;
                                     const pr = _f;
@@ -1119,8 +1121,8 @@ function labeler() {
                         }
                         // Merge manually added labels with the ones to add
                         const finalLabels = Array.from(new Set([
-                            ...latestLabels.filter(label => !syncLabels || allLabels.has(label)), // Keep only labels that match the config if sync-labels is true
-                            ...labelsToAdd
+                            ...latestLabels, // Include all manually added labels
+                            ...labelsToAdd.filter(label => !latestLabels.includes(label)) // Add only new labels
                         ])).slice(0, GITHUB_MAX_LABELS);
                         yield api.setLabels(client, pullRequest.number, finalLabels);
                         // Ensure outputs are scoped to the current PR

--- a/dist/index.js
+++ b/dist/index.js
@@ -1121,7 +1121,7 @@ function labeler() {
                         }
                         // Merge manually added labels with the ones to add
                         const finalLabels = Array.from(new Set([
-                            ...latestLabels.filter(label => !allLabels.has(label)), // Include manually added labels not in the configuration
+                            ...latestLabels.filter(label => !preexistingLabels.includes(label)), // Include manually added labels not in the configuration
                             ...labelsToAdd // Include labels that match the configuration
                         ])).slice(0, GITHUB_MAX_LABELS);
                         yield api.setLabels(client, pullRequest.number, finalLabels);

--- a/dist/index.js
+++ b/dist/index.js
@@ -1087,19 +1087,19 @@ function labeler() {
                         allLabels.delete(label);
                     }
                 }
-                const labelsToAdd = [...allLabels].slice(0, GITHUB_MAX_LABELS);
+                const labelsToApply = [...allLabels].slice(0, GITHUB_MAX_LABELS);
                 const excessLabels = [...allLabels].slice(GITHUB_MAX_LABELS);
-                let finalLabels = Array.from(new Set(labelsToAdd));
+                let finalLabels = Array.from(new Set(labelsToApply));
                 let newLabels = [];
                 if (delayBeforeSet > 0) {
                     core.warning(`[debug] Sleeping ${delayBeforeSet}ms before setLabels call (window to add a label that will likely SURVIVE).`);
                     yield sleep(delayBeforeSet);
                 }
                 try {
-                    if (!(0, lodash_isequal_1.default)(labelsToAdd, preexistingLabels)) {
+                    if (!(0, lodash_isequal_1.default)(labelsToApply, preexistingLabels)) {
                         core.info(`[debug] Snapshot preexistingLabels: ${JSON.stringify(preexistingLabels)}`);
-                        core.info(`[debug] About to set labels: ${JSON.stringify(labelsToAdd)}`);
-                        // Fetch the latest labels for the current pull request
+                        core.info(`[debug] About to set labels: ${JSON.stringify(labelsToApply)}`);
+                        // Fetch the latest labels for the PR
                         const latestLabels = [];
                         if (process.env.NODE_ENV !== 'test') {
                             try {
@@ -1120,16 +1120,16 @@ function labeler() {
                                 finally { if (e_2) throw e_2.error; }
                             }
                         }
-                        // Merge manually added labels and config-matched labels
-                        const manuallyAdded = latestLabels.filter(l => !preexistingLabels.includes(l));
-                        finalLabels = Array.from(new Set([...manuallyAdded, ...labelsToAdd])).slice(0, GITHUB_MAX_LABELS);
+                        // Detect manually added labels during run
+                        const manualAddedDuringRun = latestLabels.filter(l => !preexistingLabels.includes(l));
+                        // Merge manual and config-based labels (dedupe + limit)
+                        finalLabels = [...new Set([...manualAddedDuringRun, ...labelsToApply])]
+                            .slice(0, GITHUB_MAX_LABELS);
                         yield api.setLabels(client, pullRequest.number, finalLabels);
                         newLabels = finalLabels.filter(l => !preexistingLabels.includes(l));
                         core.debug(`PR #${pullRequest.number}`);
                         core.debug(`Latest labels: ${JSON.stringify(latestLabels)}`);
                         core.debug(`Final labels: ${JSON.stringify(finalLabels)}`);
-                        core.setOutput('new-labels', newLabels.join(','));
-                        core.setOutput('all-labels', finalLabels.join(','));
                     }
                 }
                 catch (error) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1121,8 +1121,8 @@ function labeler() {
                         }
                         // Merge manually added labels with the ones to add
                         const finalLabels = Array.from(new Set([
-                            ...latestLabels, // Include all manually added labels
-                            ...labelsToAdd.filter(label => !latestLabels.includes(label)) // Add only new labels
+                            ...latestLabels.filter(label => !allLabels.has(label)), // Include manually added labels not in the configuration
+                            ...labelsToAdd // Include labels that match the configuration
                         ])).slice(0, GITHUB_MAX_LABELS);
                         yield api.setLabels(client, pullRequest.number, finalLabels);
                         // Ensure outputs are scoped to the current PR

--- a/src/get-inputs/get-inputs.ts
+++ b/src/get-inputs/get-inputs.ts
@@ -6,5 +6,17 @@ export const getInputs = () => ({
   configPath: core.getInput('configuration-path', {required: true}),
   syncLabels: core.getBooleanInput('sync-labels'),
   dot: core.getBooleanInput('dot'),
-  prNumbers: getPrNumbers()
+  prNumbers: getPrNumbers(),
+  debugDelayBeforeFetch: parseInt(
+    core.getInput('debug-delay-before-fetch-ms') || '0',
+    10
+  ),
+  debugDelayBeforeSet: parseInt(
+    core.getInput('debug-delay-before-set-ms') || '0',
+    10
+  ),
+  debugDelayAfterSet: parseInt(
+    core.getInput('debug-delay-after-set-ms') || '0',
+    10
+  )
 });

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -108,8 +108,8 @@ export async function labeler() {
         // Merge manually added labels with the ones to add
         const finalLabels = Array.from(
           new Set([
-            ...latestLabels, // Include all manually added labels
-            ...labelsToAdd.filter(label => !latestLabels.includes(label)) // Add only new labels
+            ...latestLabels.filter(label => !allLabels.has(label)), // Include manually added labels not in the configuration
+            ...labelsToAdd // Include labels that match the configuration
           ])
         ).slice(0, GITHUB_MAX_LABELS);
 

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -108,10 +108,8 @@ export async function labeler() {
         // Merge manually added labels with the ones to add
         const finalLabels = Array.from(
           new Set([
-            ...latestLabels.filter(
-              label => !syncLabels || allLabels.has(label)
-            ), // Keep only labels that match the config if sync-labels is true
-            ...labelsToAdd
+            ...latestLabels, // Include all manually added labels
+            ...labelsToAdd.filter(label => !latestLabels.includes(label)) // Add only new labels
           ])
         ).slice(0, GITHUB_MAX_LABELS);
 

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -116,7 +116,7 @@ export async function labeler() {
         await api.setLabels(client, pullRequest.number, finalLabels);
 
         // Ensure outputs are scoped to the current PR
-        newLabels = labelsToAdd.filter(
+        newLabels = finalLabels.filter(
           label => !preexistingLabels.includes(label)
         );
         core.debug(`Processing PR #${pullRequest.number}`);
@@ -124,7 +124,8 @@ export async function labeler() {
         core.debug(`Labels to add: ${JSON.stringify(labelsToAdd)}`);
         core.debug(`Final labels: ${JSON.stringify(finalLabels)}`);
         core.setOutput('new-labels', newLabels.join(','));
-        core.setOutput('all-labels', [...allLabels].join(','));
+        // core.setOutput('all-labels', [...allLabels].join(','));
+        core.setOutput('all-labels', finalLabels.join(','));
       }
     } catch (error: any) {
       if (

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -90,6 +90,12 @@ export async function labeler() {
 
     try {
       if (!isEqual(labelsToAdd, preexistingLabels)) {
+        core.info(
+          `[debug] Snapshot preexistingLabels: ${JSON.stringify(preexistingLabels)}`
+        );
+        core.info(
+          `[debug] About to set labels: ${JSON.stringify(labelsToAdd)}`
+        );
         await api.setLabels(client, pullRequest.number, labelsToAdd);
         newLabels = labelsToAdd.filter(
           label => !preexistingLabels.includes(label)

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -108,7 +108,7 @@ export async function labeler() {
         // Merge manually added labels with the ones to add
         const finalLabels = Array.from(
           new Set([
-            ...latestLabels.filter(label => !allLabels.has(label)), // Include manually added labels not in the configuration
+            ...latestLabels.filter(label => !preexistingLabels.includes(label)), // Include manually added labels not in the configuration
             ...labelsToAdd // Include labels that match the configuration
           ])
         ).slice(0, GITHUB_MAX_LABELS);


### PR DESCRIPTION
**Description:**
This pull request adds enhanced debugging and instrumentation features to the labeler workflow, primarily to help observe and troubleshoot label synchronization behavior in pull requests. It introduces configurable debug delays at key points in the labeling process and improves how manually added labels are handled and preserved. The most important changes are grouped below:

**Debugging and Instrumentation Enhancements:**

* Added three new optional inputs—`debug-delay-before-fetch-ms`, `debug-delay-before-set-ms`, and `debug-delay-after-set-ms`—to `action.yml` for controlling delays at different stages of the labeling process.
* Updated `get-inputs.ts` to parse these new debug delay inputs and make them available to the labeler logic.
* Implemented a `sleep` utility and logic in `labeler.ts` to pause execution before fetching PR data, before setting labels, and after setting labels, based on the configured delays. [[1]](diffhunk://#diff-448984110104fc17eadbe4ddc66981a4282fbc78e1dd5e84daf782f4e266fe7cR19-R21) [[2]](diffhunk://#diff-448984110104fc17eadbe4ddc66981a4282fbc78e1dd5e84daf782f4e266fe7cR30-R50) [[3]](diffhunk://#diff-448984110104fc17eadbe4ddc66981a4282fbc78e1dd5e84daf782f4e266fe7cR158-R166)

**Label Synchronization Improvements:**

* Enhanced the label synchronization logic to fetch the latest labels from the PR, merge manually added labels with those matched by config, and ensure manually added labels are preserved rather than overwritten. The final set of labels is deduplicated and capped at the GitHub maximum.
* The output for `all-labels` now correctly reflects the final set of labels actually applied to the PR, including any manually added labels that survived the sync process.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.