### PR TITLE
Fix: Preserve manually added labels during workflow run and refine label sync logic

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,18 @@ inputs:
   pr-number:
     description: 'The pull request number(s)'
     required: false
+  debug-delay-before-fetch-ms:
+    description: 'Debug delay in ms before fetching PR labels'
+    required: false
+    default: '0'
+  debug-delay-before-set-ms:
+    description: 'Debug delay in ms before calling setLabels'
+    required: false
+    default: '0'
+  debug-delay-after-set-ms:
+    description: 'Debug delay in ms after calling setLabels'
+    required: false
+    default: '0'
 
 outputs:
   new-labels:

--- a/dist/index.js
+++ b/dist/index.js
@@ -1053,7 +1053,7 @@ const run = () => labeler().catch(error => {
 exports.run = run;
 function labeler() {
     return __awaiter(this, void 0, void 0, function* () {
-        var _a, e_1, _b, _c, _d, e_2, _e, _f;
+        var _a, e_1, _b, _c;
         const { token, configPath, syncLabels, dot, prNumbers } = (0, get_inputs_1.getInputs)();
         // --- Debug delays (instrumentation) ---
         const delayBeforeFetch = parseInt(process.env['LABELER_DEBUG_DELAY_BEFORE_FETCH_MS'] || '0', 10);
@@ -1071,9 +1071,9 @@ function labeler() {
         const client = github.getOctokit(token, {}, pluginRetry.retry);
         const pullRequests = api.getPullRequests(client, prNumbers);
         try {
-            for (var _g = true, pullRequests_1 = __asyncValues(pullRequests), pullRequests_1_1; pullRequests_1_1 = yield pullRequests_1.next(), _a = pullRequests_1_1.done, !_a; _g = true) {
+            for (var _d = true, pullRequests_1 = __asyncValues(pullRequests), pullRequests_1_1; pullRequests_1_1 = yield pullRequests_1.next(), _a = pullRequests_1_1.done, !_a; _d = true) {
                 _c = pullRequests_1_1.value;
-                _g = false;
+                _d = false;
                 const pullRequest = _c;
                 const labelConfigs = yield api.getLabelConfigs(client, configPath);
                 const preexistingLabels = pullRequest.data.labels.map(l => l.name);
@@ -1102,23 +1102,8 @@ function labeler() {
                         // Fetch the latest labels for the PR
                         const latestLabels = [];
                         if (process.env.NODE_ENV !== 'test') {
-                            try {
-                                for (var _h = true, _j = (e_2 = void 0, __asyncValues(api.getPullRequests(client, [
-                                    pullRequest.number
-                                ]))), _k; _k = yield _j.next(), _d = _k.done, !_d; _h = true) {
-                                    _f = _k.value;
-                                    _h = false;
-                                    const pr = _f;
-                                    latestLabels.push(...pr.data.labels.map(l => l.name));
-                                }
-                            }
-                            catch (e_2_1) { e_2 = { error: e_2_1 }; }
-                            finally {
-                                try {
-                                    if (!_h && !_d && (_e = _j.return)) yield _e.call(_j);
-                                }
-                                finally { if (e_2) throw e_2.error; }
-                            }
+                            const pr = yield client.rest.pulls.get(Object.assign(Object.assign({}, github.context.repo), { pull_number: pullRequest.number }));
+                            latestLabels.push(...pr.data.labels.map(l => l.name));
                         }
                         // Detect manually added labels during run
                         const manualAddedDuringRun = latestLabels.filter(l => !preexistingLabels.includes(l));
@@ -1165,7 +1150,7 @@ function labeler() {
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
         finally {
             try {
-                if (!_g && !_a && (_b = pullRequests_1.return)) yield _b.call(pullRequests_1);
+                if (!_d && !_a && (_b = pullRequests_1.return)) yield _b.call(pullRequests_1);
             }
             finally { if (e_1) throw e_1.error; }
         }

--- a/src/get-inputs/get-inputs.ts
+++ b/src/get-inputs/get-inputs.ts
@@ -6,5 +6,17 @@ export const getInputs = () => ({
   configPath: core.getInput('configuration-path', {required: true}),
   syncLabels: core.getBooleanInput('sync-labels'),
   dot: core.getBooleanInput('dot'),
-  prNumbers: getPrNumbers()
+  prNumbers: getPrNumbers(),
+  debugDelayBeforeFetch: parseInt(
+    core.getInput('debug-delay-before-fetch-ms') || '0',
+    10
+  ),
+  debugDelayBeforeSet: parseInt(
+    core.getInput('debug-delay-before-set-ms') || '0',
+    10
+  ),
+  debugDelayAfterSet: parseInt(
+    core.getInput('debug-delay-after-set-ms') || '0',
+    10
+  )
 });

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -99,11 +99,11 @@ export async function labeler() {
         // Fetch the latest labels for the PR
         const latestLabels: string[] = [];
         if (process.env.NODE_ENV !== 'test') {
-          for await (const pr of api.getPullRequests(client, [
-            pullRequest.number
-          ])) {
-            latestLabels.push(...pr.data.labels.map(l => l.name));
-          }
+          const pr = await client.rest.pulls.get({
+            ...github.context.repo,
+            pull_number: pullRequest.number
+          });
+          latestLabels.push(...pr.data.labels.map(l => l.name));
         }
 
         // Detect manually added labels during run


### PR DESCRIPTION
**Description:**
This PR updates the label synchronization logic to ensure that manually added labels during a workflow run are not removed or overwritten when the labeler action executes. It improves consistency between the actual PR state and the intended label configuration while maintaining backward compatibility.

**Debugging instrumentation:**

* Added three new input parameters (`debug-delay-before-fetch-ms`, `debug-delay-before-set-ms`, `debug-delay-after-set-ms`) to `action.yml` to allow configurable delays before fetching PR labels, before setting labels, and after setting labels.
* Updated `get-inputs.ts` to parse and expose these debug delay inputs for use in the labeler logic.
* Implemented the delays in `labeler.ts` using a new `sleep` utility and warnings to indicate when each delay occurs. [[1]](diffhunk://#diff-448984110104fc17eadbe4ddc66981a4282fbc78e1dd5e84daf782f4e266fe7cR19-R21) [[2]](diffhunk://#diff-448984110104fc17eadbe4ddc66981a4282fbc78e1dd5e84daf782f4e266fe7cR30-R50) [[3]](diffhunk://#diff-448984110104fc17eadbe4ddc66981a4282fbc78e1dd5e84daf782f4e266fe7cR157-R165)

**Label handling improvements:**

* Enhanced the label application logic to fetch the latest labels before setting new ones, detect any labels manually added during the run, and merge them with config-based labels, ensuring deduplication and adherence to the GitHub label limit. The output now reflects the final set of labels applied to the PR. [[1]](diffhunk://#diff-448984110104fc17eadbe4ddc66981a4282fbc78e1dd5e84daf782f4e266fe7cL54-R125) [[2]](diffhunk://#diff-448984110104fc17eadbe4ddc66981a4282fbc78e1dd5e84daf782f4e266fe7cR157-R165)

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.