### PR TITLE
fix: validate pr-number input to reject non-numeric, zero, and negative values

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -441,6 +441,88 @@ describe('run', () => {
     );
   });
 
+  it('(with pr-number: non-numeric string) warns and makes no API call', async () => {
+    configureInput({
+      'repo-token': 'foo',
+      'configuration-path': 'bar',
+      'pr-number': ['abc']
+    });
+
+    usingLabelerConfigYaml('only_pdfs.yml');
+
+    await run();
+
+    expect(coreWarningMock).toHaveBeenCalledWith(
+      "'abc' is not a valid pull request number"
+    );
+    expect(getPullMock).not.toHaveBeenCalled();
+    expect(setLabelsMock).not.toHaveBeenCalled();
+  });
+
+  it('(with pr-number: negative number) warns and makes no API call', async () => {
+    configureInput({
+      'repo-token': 'foo',
+      'configuration-path': 'bar',
+      'pr-number': ['-1']
+    });
+
+    usingLabelerConfigYaml('only_pdfs.yml');
+
+    await run();
+
+    expect(coreWarningMock).toHaveBeenCalledWith(
+      "'-1' is not a valid pull request number"
+    );
+    expect(getPullMock).not.toHaveBeenCalled();
+    expect(setLabelsMock).not.toHaveBeenCalled();
+  });
+
+  it('(with pr-number: zero) warns and makes no API call', async () => {
+    configureInput({
+      'repo-token': 'foo',
+      'configuration-path': 'bar',
+      'pr-number': ['0']
+    });
+
+    usingLabelerConfigYaml('only_pdfs.yml');
+
+    await run();
+
+    expect(coreWarningMock).toHaveBeenCalledWith(
+      "'0' is not a valid pull request number"
+    );
+    expect(getPullMock).not.toHaveBeenCalled();
+    expect(setLabelsMock).not.toHaveBeenCalled();
+  });
+
+  it('(with pr-number: mix of valid and invalid) processes valid, skips invalid with warning', async () => {
+    configureInput({
+      'repo-token': 'foo',
+      'configuration-path': 'bar',
+      'pr-number': ['104', 'abc']
+    });
+
+    usingLabelerConfigYaml('only_pdfs.yml');
+    mockGitHubResponseChangedFiles('foo.pdf');
+
+    getPullMock.mockResolvedValue(<any>{
+      data: {labels: []}
+    });
+
+    await run();
+
+    expect(coreWarningMock).toHaveBeenCalledWith(
+      "'abc' is not a valid pull request number"
+    );
+    expect(setLabelsMock).toHaveBeenCalledTimes(1);
+    expect(setLabelsMock).toHaveBeenCalledWith({
+      owner: 'monalisa',
+      repo: 'helloworld',
+      issue_number: 104,
+      labels: ['touched-a-pdf-file']
+    });
+  });
+
   it('does not add labels to PRs that have no changed files', async () => {
     usingLabelerConfigYaml('only_pdfs.yml');
     mockGitHubResponseChangedFiles();

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -495,6 +495,60 @@ describe('run', () => {
     expect(setLabelsMock).not.toHaveBeenCalled();
   });
 
+  it('(with pr-number: string with carriage return) sanitizes CR as \\x0d in warning', async () => {
+    configureInput({
+      'repo-token': 'foo',
+      'configuration-path': 'bar',
+      'pr-number': ['abc\rdef']
+    });
+
+    usingLabelerConfigYaml('only_pdfs.yml');
+
+    await run();
+
+    expect(coreWarningMock).toHaveBeenCalledWith(
+      "'abc\\x0ddef' is not a valid pull request number"
+    );
+    expect(getPullMock).not.toHaveBeenCalled();
+    expect(setLabelsMock).not.toHaveBeenCalled();
+  });
+
+  it('(with pr-number: string with tab) sanitizes tab as \\x09 in warning', async () => {
+    configureInput({
+      'repo-token': 'foo',
+      'configuration-path': 'bar',
+      'pr-number': ['abc\tdef']
+    });
+
+    usingLabelerConfigYaml('only_pdfs.yml');
+
+    await run();
+
+    expect(coreWarningMock).toHaveBeenCalledWith(
+      "'abc\\x09def' is not a valid pull request number"
+    );
+    expect(getPullMock).not.toHaveBeenCalled();
+    expect(setLabelsMock).not.toHaveBeenCalled();
+  });
+
+  it('(with pr-number: string with ANSI escape sequence) sanitizes ESC byte as \\x1b in warning', async () => {
+    configureInput({
+      'repo-token': 'foo',
+      'configuration-path': 'bar',
+      'pr-number': ['abc\x1b[31mINJECTED\x1b[0m']
+    });
+
+    usingLabelerConfigYaml('only_pdfs.yml');
+
+    await run();
+
+    expect(coreWarningMock).toHaveBeenCalledWith(
+      "'abc\\x1b[31mINJECTED\\x1b[0m' is not a valid pull request number"
+    );
+    expect(getPullMock).not.toHaveBeenCalled();
+    expect(setLabelsMock).not.toHaveBeenCalled();
+  });
+
   it('(with pr-number: mix of valid and invalid) processes valid, skips invalid with warning', async () => {
     configureInput({
       'repo-token': 'foo',

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -495,6 +495,61 @@ describe('run', () => {
     expect(setLabelsMock).not.toHaveBeenCalled();
   });
 
+  it('(with pr-number: number with internal space) warns and makes no API call', async () => {
+    configureInput({
+      'repo-token': 'foo',
+      'configuration-path': 'bar',
+      'pr-number': ['10 4']
+    });
+
+    usingLabelerConfigYaml('only_pdfs.yml');
+
+    await run();
+
+    expect(coreWarningMock).toHaveBeenCalledWith(
+      "'10 4' is not a valid pull request number"
+    );
+    expect(getPullMock).not.toHaveBeenCalled();
+    expect(setLabelsMock).not.toHaveBeenCalled();
+  });
+
+  it('(with pr-number: number with trailing non-numeric chars) warns and makes no API call', async () => {
+    configureInput({
+      'repo-token': 'foo',
+      'configuration-path': 'bar',
+      'pr-number': ['104abc']
+    });
+
+    usingLabelerConfigYaml('only_pdfs.yml');
+
+    await run();
+
+    expect(coreWarningMock).toHaveBeenCalledWith(
+      "'104abc' is not a valid pull request number"
+    );
+    expect(getPullMock).not.toHaveBeenCalled();
+    expect(setLabelsMock).not.toHaveBeenCalled();
+  });
+
+  it('(with pr-number: valid number with surrounding whitespace) trims and processes correctly', async () => {
+    configureInput({
+      'repo-token': 'foo',
+      'configuration-path': 'bar',
+      'pr-number': [' 104 ']
+    });
+
+    usingLabelerConfigYaml('only_pdfs.yml');
+    mockGitHubResponseChangedFiles('foo.pdf');
+    getPullMock.mockResolvedValue(<any>{data: {labels: []}});
+
+    await run();
+
+    expect(getPullMock).toHaveBeenCalled();
+    expect(coreWarningMock).not.toHaveBeenCalledWith(
+      expect.stringContaining('is not a valid pull request number')
+    );
+  });
+
   it('(with pr-number: string with carriage return) sanitizes CR as \\x0d in warning', async () => {
     configureInput({
       'repo-token': 'foo',
@@ -507,7 +562,7 @@ describe('run', () => {
     await run();
 
     expect(coreWarningMock).toHaveBeenCalledWith(
-      "'abc\\x0ddef' is not a valid pull request number"
+      "'abc\\x0ddef' is not a valid pull request number (non-printable characters were escaped as \\xNN)"
     );
     expect(getPullMock).not.toHaveBeenCalled();
     expect(setLabelsMock).not.toHaveBeenCalled();
@@ -525,7 +580,7 @@ describe('run', () => {
     await run();
 
     expect(coreWarningMock).toHaveBeenCalledWith(
-      "'abc\\x09def' is not a valid pull request number"
+      "'abc\\x09def' is not a valid pull request number (non-printable characters were escaped as \\xNN)"
     );
     expect(getPullMock).not.toHaveBeenCalled();
     expect(setLabelsMock).not.toHaveBeenCalled();
@@ -543,7 +598,7 @@ describe('run', () => {
     await run();
 
     expect(coreWarningMock).toHaveBeenCalledWith(
-      "'abc\\x1b[31mINJECTED\\x1b[0m' is not a valid pull request number"
+      "'abc\\x1b[31mINJECTED\\x1b[0m' is not a valid pull request number (non-printable characters were escaped as \\xNN)"
     );
     expect(getPullMock).not.toHaveBeenCalled();
     expect(setLabelsMock).not.toHaveBeenCalled();

--- a/dist/index.js
+++ b/dist/index.js
@@ -1003,8 +1003,8 @@ const getPrNumbers = () => {
     const result = [];
     for (const line of prInput) {
         const prNumber = parseInt(line, 10);
-        if (isNaN(prNumber) && prNumber <= 0) {
-            core.warning(`'${prNumber}' is not a valid pull request number`);
+        if (isNaN(prNumber) || prNumber <= 0) {
+            core.warning(`'${line}' is not a valid pull request number`);
             continue;
         }
         result.push(prNumber);

--- a/dist/index.js
+++ b/dist/index.js
@@ -1006,9 +1006,14 @@ const getPrNumbers = () => {
     }
     const result = [];
     for (const line of prInput) {
-        const prNumber = parseInt(line, 10);
-        if (isNaN(prNumber) || prNumber <= 0) {
-            core.warning(`'${(0, exports.sanitizeForWarning)(line)}' is not a valid pull request number`);
+        const trimmed = line.trim();
+        const prNumber = parseInt(trimmed, 10);
+        if (isNaN(prNumber) || prNumber <= 0 || String(prNumber) !== trimmed) {
+            const sanitized = (0, exports.sanitizeForWarning)(line);
+            const hint = sanitized !== line
+                ? ' (non-printable characters were escaped as \\xNN)'
+                : '';
+            core.warning(`'${sanitized}' is not a valid pull request number${hint}`);
             continue;
         }
         result.push(prNumber);

--- a/dist/index.js
+++ b/dist/index.js
@@ -991,10 +991,14 @@ var __importStar = (this && this.__importStar) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getPrNumbers = void 0;
+exports.getPrNumbers = exports.sanitizeForWarning = void 0;
 const core = __importStar(__nccwpck_require__(7484));
 const github = __importStar(__nccwpck_require__(3228));
 const getPrNumberFromContext = () => { var _a; return (_a = github.context.payload.pull_request) === null || _a === void 0 ? void 0 : _a.number; };
+const sanitizeForWarning = (value) => {
+    return value.replace(/[\x00-\x1F\x7F-\x9F]/g, c => `\\x${c.charCodeAt(0).toString(16).padStart(2, '0')}`);
+};
+exports.sanitizeForWarning = sanitizeForWarning;
 const getPrNumbers = () => {
     const prInput = core.getMultilineInput('pr-number');
     if (!(prInput === null || prInput === void 0 ? void 0 : prInput.length)) {
@@ -1004,7 +1008,7 @@ const getPrNumbers = () => {
     for (const line of prInput) {
         const prNumber = parseInt(line, 10);
         if (isNaN(prNumber) || prNumber <= 0) {
-            core.warning(`'${line}' is not a valid pull request number`);
+            core.warning(`'${JSON.stringify(line)}' is not a valid pull request number`);
             continue;
         }
         result.push(prNumber);

--- a/dist/index.js
+++ b/dist/index.js
@@ -1008,7 +1008,7 @@ const getPrNumbers = () => {
     for (const line of prInput) {
         const prNumber = parseInt(line, 10);
         if (isNaN(prNumber) || prNumber <= 0) {
-            core.warning(`'${JSON.stringify(line)}' is not a valid pull request number`);
+            core.warning(`'${(0, exports.sanitizeForWarning)(line)}' is not a valid pull request number`);
             continue;
         }
         result.push(prNumber);

--- a/src/get-inputs/get-pr-numbers.ts
+++ b/src/get-inputs/get-pr-numbers.ts
@@ -16,8 +16,8 @@ export const getPrNumbers = (): number[] => {
   for (const line of prInput) {
     const prNumber = parseInt(line, 10);
 
-    if (isNaN(prNumber) && prNumber <= 0) {
-      core.warning(`'${prNumber}' is not a valid pull request number`);
+    if (isNaN(prNumber) || prNumber <= 0) {
+      core.warning(`'${line}' is not a valid pull request number`);
       continue;
     }
 

--- a/src/get-inputs/get-pr-numbers.ts
+++ b/src/get-inputs/get-pr-numbers.ts
@@ -25,7 +25,7 @@ export const getPrNumbers = (): number[] => {
 
     if (isNaN(prNumber) || prNumber <= 0) {
       core.warning(
-        `'${JSON.stringify(line)}' is not a valid pull request number`
+        `'${sanitizeForWarning(line)}' is not a valid pull request number`
       );
       continue;
     }

--- a/src/get-inputs/get-pr-numbers.ts
+++ b/src/get-inputs/get-pr-numbers.ts
@@ -4,6 +4,13 @@ import * as github from '@actions/github';
 const getPrNumberFromContext = () =>
   github.context.payload.pull_request?.number;
 
+export const sanitizeForWarning = (value: string): string => {
+  return value.replace(
+    /[\x00-\x1F\x7F-\x9F]/g,
+    c => `\\x${c.charCodeAt(0).toString(16).padStart(2, '0')}`
+  );
+};
+
 export const getPrNumbers = (): number[] => {
   const prInput = core.getMultilineInput('pr-number');
 
@@ -17,7 +24,9 @@ export const getPrNumbers = (): number[] => {
     const prNumber = parseInt(line, 10);
 
     if (isNaN(prNumber) || prNumber <= 0) {
-      core.warning(`'${line}' is not a valid pull request number`);
+      core.warning(
+        `'${JSON.stringify(line)}' is not a valid pull request number`
+      );
       continue;
     }
 

--- a/src/get-inputs/get-pr-numbers.ts
+++ b/src/get-inputs/get-pr-numbers.ts
@@ -21,12 +21,16 @@ export const getPrNumbers = (): number[] => {
   const result: number[] = [];
 
   for (const line of prInput) {
-    const prNumber = parseInt(line, 10);
+    const trimmed = line.trim();
+    const prNumber = parseInt(trimmed, 10);
 
-    if (isNaN(prNumber) || prNumber <= 0) {
-      core.warning(
-        `'${sanitizeForWarning(line)}' is not a valid pull request number`
-      );
+    if (isNaN(prNumber) || prNumber <= 0 || String(prNumber) !== trimmed) {
+      const sanitized = sanitizeForWarning(line);
+      const hint =
+        sanitized !== line
+          ? ' (non-printable characters were escaped as \\xNN)'
+          : '';
+      core.warning(`'${sanitized}' is not a valid pull request number${hint}`);
       continue;
     }
 


### PR DESCRIPTION
**Description:**
This pull request enhances validation and sanitization of the `pr-number` input, improving robustness and user feedback when invalid pull request numbers are provided. It adds comprehensive test coverage for various invalid and edge-case inputs, ensuring that only properly formatted, positive numeric PR numbers are processed, and that warnings are clear and safe.

The most important changes include:

**Validation and Sanitization Improvements:**

* Added a `sanitizeForWarning` function in `get-pr-numbers.ts` to escape non-printable characters in warning messages, preventing potential issues with control characters or terminal escape sequences.
* Improved validation logic in `getPrNumbers` to reject non-numeric, negative, zero, or improperly formatted PR numbers (including those with extra spaces or characters), and to provide sanitized, informative warnings.

**Test Coverage:**

* Added multiple test cases in `main.test.ts` to verify that invalid `pr-number` values (such as non-numeric strings, negative numbers, zero, numbers with spaces, trailing characters, and those containing non-printable or escape characters) are correctly rejected with appropriate warnings, and that valid numbers (even with surrounding whitespace) are accepted and processed.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.